### PR TITLE
feat(dev): add clean_codex.sh to reset macOS app data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,7 @@ git apply --reject ../patches/problem.patch   # Apply with .rej files for confli
 | `dev/build.sh` | Local development build |
 | `dev/patch.sh` | Apply patches for editing a single patch |
 | `dev/update_patches.sh` | Validate/update all patches |
+| `dev/clean_codex.sh` | Remove all Codex app data from macOS user dirs (reset to clean state; macOS only) |
 | `utils.sh` | Common functions including `apply_patch` |
 
 ## Build Environment

--- a/dev/clean_codex.sh
+++ b/dev/clean_codex.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# dev/clean_codex.sh — Remove all Codex application data from macOS user directories.
+#
+# Use this to reset Codex to a clean state: wipes preferences, caches, saved
+# window state, and recent-document entries. Useful after upgrades or when
+# diagnosing misbehaviour caused by stale data.
+#
+# Usage:
+#   ./dev/clean_codex.sh
+#
+# The script lists every matched path with its size, then prompts for
+# confirmation before deleting anything. Press Enter to proceed or Ctrl-C
+# to abort. No changes are made until you confirm.
+#
+# Requirements: bash 4+ (macOS ships 3.2 — install via: brew install bash)
+# Platform:     macOS only
+
+set -euo pipefail
+
+# Requires bash 4+ (for globstar and associative arrays)
+if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+    echo "Error: This script requires bash 4+."
+    echo "macOS ships bash 3.2 — install a newer version via Homebrew: brew install bash"
+    echo "Then ensure /opt/homebrew/bin is first in your \$PATH."
+    exit 1
+fi
+
+user=$USER
+
+# List of paths to delete (supports ** recursive matching via globstar)
+read -r -d '' PATHS_LIST << EOF || true
+/Users/$user/.codex*
+/Users/$user/Library/Application Support/Codex
+/Users/$user/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.codex*
+/Users/$user/Library/Autosave Information/com.codex.plist
+/Users/$user/Library/Saved Application State/com.codex*
+/Users/$user/Library/Saved Application State/com.codex.savedState
+/private/var/folders/**/*com.codex*
+EOF
+
+# Enable globstar for ** recursive matching, nullglob so unmatched globs expand to nothing
+shopt -s globstar nullglob
+
+# Collect all glob pattern lines
+glob_lines=()
+while IFS= read -r pattern; do
+    [[ -z "$pattern" ]] && continue
+    glob_lines+=("$pattern")
+done <<< "$PATHS_LIST"
+
+# Resolve globs to actual files and collect unique matches
+declare -A seen
+matched_files=()
+
+for pattern in "${glob_lines[@]}"; do
+    # Disable word splitting so spaces in paths don't cause breakage,
+    # while still allowing glob expansion
+    old_ifs="$IFS"
+    IFS=''
+    matches=($pattern)
+    IFS="$old_ifs"
+
+    for match in "${matches[@]}"; do
+        if [[ -e "$match" ]] && [[ -z "${seen["$match"]:-}" ]]; then
+            seen["$match"]=1
+            matched_files+=("$match")
+        fi
+    done
+done
+
+# Format file size to human-readable
+human_size() {
+    local bytes=$1
+    if (( bytes >= 1073741824 )); then
+        awk "BEGIN { printf \"%.1fG\", $bytes / 1073741824 }"
+    elif (( bytes >= 1048576 )); then
+        awk "BEGIN { printf \"%.1fM\", $bytes / 1048576 }"
+    elif (( bytes >= 1024 )); then
+        awk "BEGIN { printf \"%.1fK\", $bytes / 1024 }"
+    else
+        printf "%dB" "$bytes"
+    fi
+}
+
+# Get size of a path (recursive for directories)
+get_size() {
+    local path="$1"
+    if [[ -d "$path" ]]; then
+        du -sk "$path" 2>/dev/null | awk '{print $1 * 1024}' || echo 0
+    elif [[ -f "$path" ]]; then
+        stat -f%z "$path" 2>/dev/null || echo 0
+    else
+        echo 0
+    fi
+}
+
+# Print output
+echo ""
+echo "From the following globs:"
+for g in "${glob_lines[@]}"; do
+    echo "  $g"
+done
+
+echo ""
+if [[ ${#matched_files[@]} -eq 0 ]]; then
+    echo "No files matched."
+    exit 0
+fi
+
+echo "These files will be deleted:"
+total_bytes=0
+for f in "${matched_files[@]}"; do
+    size_bytes=$(get_size "$f")
+    size_human=$(human_size "$size_bytes")
+    total_bytes=$((total_bytes + size_bytes))
+    echo "  $f  ($size_human)"
+done
+
+echo ""
+echo "Total: $(human_size $total_bytes)"
+echo ""
+read -r -p "Enter to continue, ctrl-c to cancel "
+
+# Actually delete
+failed=0
+for f in "${matched_files[@]}"; do
+    if ! rm -rf "$f"; then
+        echo "  ⚠ Failed to delete: $f" >&2
+        failed=$((failed + 1))
+    fi
+done
+
+echo ""
+if [[ $failed -gt 0 ]]; then
+    echo "Done with $failed error(s). Some files may require elevated privileges."
+else
+    echo "Done. All files deleted successfully."
+fi

--- a/docs/howto-build.md
+++ b/docs/howto-build.md
@@ -12,6 +12,7 @@
 - [Patch Update Process](#patch-update-process)
   - [Semi-Automated](#patch-update-process-semiauto)
   - [Manual](#patch-update-process-manual)
+- [Resetting Codex App Data](#clean-state)
 
 ## <a id="dependencies"></a>Dependencies
 
@@ -161,6 +162,22 @@ review-tools.snap-review --allow-classic codex*.snap
 - run `npm run watch`
 - run `./script/code.sh` until everything is ok
 - go back to the command line running `./dev/patch.sh`, press `enter` to validate the changes and it will update the patch
+
+### <a id="clean-state"></a>Resetting Codex App Data (macOS only)
+
+If you need to wipe all Codex application data between test builds (preferences, caches, saved state), use:
+
+```bash
+./dev/clean_codex.sh
+```
+
+The script shows a list of matched paths and their sizes, then prompts for confirmation before deleting. It targets:
+
+- `~/.codex*`
+- `~/Library/Application Support/Codex`
+- macOS saved state, autosave, and recent documents entries
+
+> **Note:** Requires bash 4+ (macOS ships bash 3.2 — install via `brew install bash`).
 
 ### <a id="icons"></a>icons/build_icons.sh
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,6 +4,8 @@
 
 ## Table of Contents
 
+- [macOS](#macos)
+  - [Reset all Codex application data](#macos-reset)
 - [Linux](#linux)
   - [Fonts showing up as rectangles](#linux-fonts-rectangle)
   - [Text and/or the entire interface not appearing](#linux-rendering-glitches)
@@ -11,6 +13,20 @@
   - [Flatpak most common issues](#linux-flatpak-most-common-issues)
   - [Remote SSH doesn't work](#linux-remote-ssh)
   - [The window doesn't show up](#linux-no-window)
+
+## <a id="macos"></a>macOS
+
+### <a id="macos-reset"></a>*Reset all Codex application data*
+
+If Codex is behaving unexpectedly after an upgrade (corrupted preferences, stale caches, broken saved state), you can wipe all application data and start fresh:
+
+```bash
+./dev/clean_codex.sh
+```
+
+The script lists everything it will delete with sizes and prompts for confirmation. After running it, relaunch Codex — it will start as if freshly installed.
+
+> **Note:** Requires bash 4+. macOS ships bash 3.2 — install a newer version via `brew install bash` and ensure `/opt/homebrew/bin` is first in your `$PATH`.
 
 ## <a id="linux"></a>Linux
 


### PR DESCRIPTION
## Summary

- Adds `dev/clean_codex.sh`, a macOS utility to wipe all Codex application data (preferences, caches, saved state) between test builds or when troubleshooting
- Shows matched paths with sizes and prompts for confirmation before deleting anything
- Documents the script in `CLAUDE.md`, `docs/howto-build.md` (new "Resetting Codex App Data" section), and `docs/troubleshooting.md` (new macOS section)

## Test plan

- [x] Run `./dev/clean_codex.sh` on macOS with bash 4+ — verify it lists matched paths and prompts before deleting
- [x] Run with no matching paths — verify it exits cleanly with "No files matched."
- [ ] Verify `bash 3.2` (macOS default) prints the version error and exits
- [x] Check docs render correctly in `docs/howto-build.md` and `docs/troubleshooting.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)