### PR TITLE
Fix Patch Rebuild skipping .deb/.rpm/.AppImage builds

### DIFF
--- a/.github/workflows/stable-linux.yml
+++ b/.github/workflows/stable-linux.yml
@@ -45,6 +45,8 @@ jobs:
       RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
       SHOULD_BUILD: ${{ env.SHOULD_BUILD }}
       SHOULD_DEPLOY: ${{ env.SHOULD_DEPLOY }}
+      PATCH_REBUILD: ${{ env.PATCH_REBUILD }}
+      CUSTOM_RELEASE_VERSION: ${{ env.CUSTOM_RELEASE_VERSION }}
 
     steps:
       - uses: actions/checkout@v4
@@ -189,6 +191,8 @@ jobs:
       RELEASE_VERSION: ${{ needs.check.outputs.RELEASE_VERSION }}
       SHOULD_BUILD: ${{ (needs.check.outputs.SHOULD_BUILD == 'yes' || github.event.inputs.generate_assets == 'true') && 'yes' || 'no' }}
       SHOULD_DEPLOY: ${{ needs.check.outputs.SHOULD_DEPLOY }}
+      PATCH_REBUILD: ${{ needs.check.outputs.PATCH_REBUILD }}
+      CUSTOM_RELEASE_VERSION: ${{ needs.check.outputs.CUSTOM_RELEASE_VERSION }}
       VSCODE_ARCH: ${{ matrix.vscode_arch }}
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     outputs:

--- a/.github/workflows/stable-windows.yml
+++ b/.github/workflows/stable-windows.yml
@@ -43,6 +43,8 @@ jobs:
       RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
       SHOULD_BUILD: ${{ env.SHOULD_BUILD }}
       SHOULD_DEPLOY: ${{ env.SHOULD_DEPLOY }}
+      PATCH_REBUILD: ${{ env.PATCH_REBUILD }}
+      CUSTOM_RELEASE_VERSION: ${{ env.CUSTOM_RELEASE_VERSION }}
 
     steps:
       - uses: actions/checkout@v4
@@ -164,6 +166,8 @@ jobs:
       RELEASE_VERSION: ${{ needs.check.outputs.RELEASE_VERSION }}
       SHOULD_BUILD: ${{ (needs.check.outputs.SHOULD_BUILD == 'yes' || github.event.inputs.generate_assets == 'true') && 'yes' || 'no' }}
       SHOULD_DEPLOY: ${{ needs.check.outputs.SHOULD_DEPLOY }}
+      PATCH_REBUILD: ${{ needs.check.outputs.PATCH_REBUILD }}
+      CUSTOM_RELEASE_VERSION: ${{ needs.check.outputs.CUSTOM_RELEASE_VERSION }}
       VSCODE_ARCH: ${{ matrix.vscode_arch }}
     outputs:
       RELEASE_VERSION: ${{ env.RELEASE_VERSION }}

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -258,14 +258,14 @@ elif [[ "${ASSETS}" != "null" ]]; then
 
         # linux-arm64
         if [[ "${VSCODE_ARCH}" == "arm64" || "${CHECK_ALL}" == "yes" ]]; then
-          if [[ -z $( contains "arm64.deb" ) ]]; then
+          if [[ -z $( contains "${RELEASE_VERSION}_arm64.deb" ) ]]; then
             echo "Building on Linux arm64 because we have no DEB"
             export SHOULD_BUILD="yes"
           else
             export SHOULD_BUILD_DEB="no"
           fi
 
-          if [[ -z $( contains "aarch64.rpm" ) ]]; then
+          if [[ -z $( contains "${RELEASE_VERSION}-el8.aarch64.rpm" ) ]]; then
             echo "Building on Linux arm64 because we have no RPM"
             export SHOULD_BUILD="yes"
           else
@@ -317,14 +317,14 @@ elif [[ "${ASSETS}" != "null" ]]; then
 
         # linux-armhf
         if [[ "${VSCODE_ARCH}" == "armhf" || "${CHECK_ALL}" == "yes" ]]; then
-          if [[ -z $( contains "armhf.deb" ) ]]; then
+          if [[ -z $( contains "${RELEASE_VERSION}_armhf.deb" ) ]]; then
             echo "Building on Linux arm because we have no DEB"
             export SHOULD_BUILD="yes"
           else
             export SHOULD_BUILD_DEB="no"
           fi
 
-          if [[ -z $( contains "armv7hl.rpm" ) ]]; then
+          if [[ -z $( contains "${RELEASE_VERSION}-el8.armv7hl.rpm" ) ]]; then
             echo "Building on Linux arm because we have no RPM"
             export SHOULD_BUILD="yes"
           else
@@ -500,14 +500,14 @@ elif [[ "${ASSETS}" != "null" ]]; then
 
         # linux-x64
         if [[ "${VSCODE_ARCH}" == "x64" || "${CHECK_ALL}" == "yes" ]]; then
-          if [[ -z $( contains "amd64.deb" ) ]]; then
+          if [[ -z $( contains "${RELEASE_VERSION}_amd64.deb" ) ]]; then
             echo "Building on Linux x64 because we have no DEB"
             export SHOULD_BUILD="yes"
           else
             export SHOULD_BUILD_DEB="no"
           fi
 
-          if [[ -z $( contains "x86_64.rpm" ) ]]; then
+          if [[ -z $( contains "${RELEASE_VERSION}-el8.x86_64.rpm" ) ]]; then
             echo "Building on Linux x64 because we have no RPM"
             export SHOULD_BUILD="yes"
           else
@@ -523,7 +523,7 @@ elif [[ "${ASSETS}" != "null" ]]; then
 
           if [[ "${DISABLE_APPIMAGE}" == "yes" ]]; then
             export SHOULD_BUILD_APPIMAGE="no"
-          elif [[ -z $( contains "x86_64.AppImage" ) ]]; then
+          elif [[ -z $( contains "${RELEASE_VERSION}.glibc" ) ]]; then
             echo "Building on Linux x64 because we have no AppImage"
             export SHOULD_BUILD="yes"
           else


### PR DESCRIPTION
Fix Patch Rebuild skipping .deb/.rpm/.AppImage builds due to missing PATCH_REBUILD propagation and version-less asset checks.

Release 1.108.11148 shipped without any .deb, .rpm, or .AppImage files. The check job correctly detected the patch rebuild and skipped asset checking, but the build matrix jobs ran their own check_tags.sh without PATCH_REBUILD set. Combined with version-less contains checks (e.g. "amd64.deb" matching the previous release's assets), the build jobs falsely concluded the packages already existed and skipped them.

## Changes

- Add PATCH_REBUILD and CUSTOM_RELEASE_VERSION as outputs of the check job in stable-linux.yml and stable-windows.yml
- Pass both variables into the build job environment so check_tags.sh can short-circuit during patch rebuilds
- Make contains checks for .deb, .rpm, and .AppImage version-specific, matching the pattern already used for .tar.gz and CLI archives (e.g. "amd64.deb" → "${RELEASE_VERSION}_amd64.deb")
- stable-macos.yml not affected (no separate check job; runs check_tags.sh inline)

## Test plan

- Trigger a Patch Rebuild after merge and verify .deb/.rpm/.AppImage appear in the release assets
- Verify a normal push-triggered build still correctly skips already-uploaded assets