### PR TITLE
Fix for deb/rpm/app image patch rebuild

### DIFF
--- a/.github/workflows/stable-linux.yml
+++ b/.github/workflows/stable-linux.yml
@@ -45,6 +45,8 @@ jobs:
       RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
       SHOULD_BUILD: ${{ env.SHOULD_BUILD }}
       SHOULD_DEPLOY: ${{ env.SHOULD_DEPLOY }}
+      PATCH_REBUILD: ${{ env.PATCH_REBUILD }}
+      CUSTOM_RELEASE_VERSION: ${{ env.CUSTOM_RELEASE_VERSION }}
 
     steps:
       - uses: actions/checkout@v4
@@ -189,6 +191,8 @@ jobs:
       RELEASE_VERSION: ${{ needs.check.outputs.RELEASE_VERSION }}
       SHOULD_BUILD: ${{ (needs.check.outputs.SHOULD_BUILD == 'yes' || github.event.inputs.generate_assets == 'true') && 'yes' || 'no' }}
       SHOULD_DEPLOY: ${{ needs.check.outputs.SHOULD_DEPLOY }}
+      PATCH_REBUILD: ${{ needs.check.outputs.PATCH_REBUILD }}
+      CUSTOM_RELEASE_VERSION: ${{ needs.check.outputs.CUSTOM_RELEASE_VERSION }}
       VSCODE_ARCH: ${{ matrix.vscode_arch }}
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     outputs:
@@ -308,6 +312,8 @@ jobs:
       RELEASE_VERSION: ${{ needs.check.outputs.RELEASE_VERSION }}
       SHOULD_BUILD: ${{ needs.check.outputs.SHOULD_BUILD }}
       SHOULD_DEPLOY: ${{ needs.check.outputs.SHOULD_DEPLOY }}
+      PATCH_REBUILD: ${{ needs.check.outputs.PATCH_REBUILD }}
+      CUSTOM_RELEASE_VERSION: ${{ needs.check.outputs.CUSTOM_RELEASE_VERSION }}
       VSCODE_ARCH: ${{ matrix.vscode_arch }}
     if: needs.check.outputs.SHOULD_BUILD == 'yes' || github.event.inputs.generate_assets == 'true'
 
@@ -409,6 +415,8 @@ jobs:
       RELEASE_VERSION: ${{ needs.check.outputs.RELEASE_VERSION }}
       SHOULD_BUILD: ${{ needs.check.outputs.SHOULD_BUILD }}
       SHOULD_DEPLOY: ${{ needs.check.outputs.SHOULD_DEPLOY }}
+      PATCH_REBUILD: ${{ needs.check.outputs.PATCH_REBUILD }}
+      CUSTOM_RELEASE_VERSION: ${{ needs.check.outputs.CUSTOM_RELEASE_VERSION }}
       VSCODE_ARCH: ${{ matrix.vscode_arch }}
     if: needs.check.outputs.SHOULD_BUILD == 'yes' || github.event.inputs.generate_assets == 'true'
 

--- a/.github/workflows/stable-windows.yml
+++ b/.github/workflows/stable-windows.yml
@@ -43,6 +43,8 @@ jobs:
       RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
       SHOULD_BUILD: ${{ env.SHOULD_BUILD }}
       SHOULD_DEPLOY: ${{ env.SHOULD_DEPLOY }}
+      PATCH_REBUILD: ${{ env.PATCH_REBUILD }}
+      CUSTOM_RELEASE_VERSION: ${{ env.CUSTOM_RELEASE_VERSION }}
 
     steps:
       - uses: actions/checkout@v4
@@ -164,6 +166,8 @@ jobs:
       RELEASE_VERSION: ${{ needs.check.outputs.RELEASE_VERSION }}
       SHOULD_BUILD: ${{ (needs.check.outputs.SHOULD_BUILD == 'yes' || github.event.inputs.generate_assets == 'true') && 'yes' || 'no' }}
       SHOULD_DEPLOY: ${{ needs.check.outputs.SHOULD_DEPLOY }}
+      PATCH_REBUILD: ${{ needs.check.outputs.PATCH_REBUILD }}
+      CUSTOM_RELEASE_VERSION: ${{ needs.check.outputs.CUSTOM_RELEASE_VERSION }}
       VSCODE_ARCH: ${{ matrix.vscode_arch }}
     outputs:
       RELEASE_VERSION: ${{ env.RELEASE_VERSION }}

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -258,14 +258,14 @@ elif [[ "${ASSETS}" != "null" ]]; then
 
         # linux-arm64
         if [[ "${VSCODE_ARCH}" == "arm64" || "${CHECK_ALL}" == "yes" ]]; then
-          if [[ -z $( contains "arm64.deb" ) ]]; then
+          if [[ -z $( contains "${APP_NAME_LC}_${RELEASE_VERSION}_arm64.deb" ) ]]; then
             echo "Building on Linux arm64 because we have no DEB"
             export SHOULD_BUILD="yes"
           else
             export SHOULD_BUILD_DEB="no"
           fi
 
-          if [[ -z $( contains "aarch64.rpm" ) ]]; then
+          if [[ -z $( contains "${APP_NAME_LC}-${RELEASE_VERSION}-el8.aarch64.rpm" ) ]]; then
             echo "Building on Linux arm64 because we have no RPM"
             export SHOULD_BUILD="yes"
           else
@@ -279,7 +279,7 @@ elif [[ "${ASSETS}" != "null" ]]; then
             export SHOULD_BUILD_TAR="no"
           fi
 
-          if [[ -z $( contains "arm64.snap" ) ]]; then
+          if [[ -z $( contains "${RELEASE_VERSION}_arm64.snap" ) ]]; then
             echo "Building on Linux arm64 because we have no SNAP"
             export SHOULD_BUILD="yes"
           else
@@ -317,14 +317,14 @@ elif [[ "${ASSETS}" != "null" ]]; then
 
         # linux-armhf
         if [[ "${VSCODE_ARCH}" == "armhf" || "${CHECK_ALL}" == "yes" ]]; then
-          if [[ -z $( contains "armhf.deb" ) ]]; then
+          if [[ -z $( contains "${APP_NAME_LC}_${RELEASE_VERSION}_armhf.deb" ) ]]; then
             echo "Building on Linux arm because we have no DEB"
             export SHOULD_BUILD="yes"
           else
             export SHOULD_BUILD_DEB="no"
           fi
 
-          if [[ -z $( contains "armv7hl.rpm" ) ]]; then
+          if [[ -z $( contains "${APP_NAME_LC}-${RELEASE_VERSION}-el8.armv7hl.rpm" ) ]]; then
             echo "Building on Linux arm because we have no RPM"
             export SHOULD_BUILD="yes"
           else
@@ -500,14 +500,14 @@ elif [[ "${ASSETS}" != "null" ]]; then
 
         # linux-x64
         if [[ "${VSCODE_ARCH}" == "x64" || "${CHECK_ALL}" == "yes" ]]; then
-          if [[ -z $( contains "amd64.deb" ) ]]; then
+          if [[ -z $( contains "${APP_NAME_LC}_${RELEASE_VERSION}_amd64.deb" ) ]]; then
             echo "Building on Linux x64 because we have no DEB"
             export SHOULD_BUILD="yes"
           else
             export SHOULD_BUILD_DEB="no"
           fi
 
-          if [[ -z $( contains "x86_64.rpm" ) ]]; then
+          if [[ -z $( contains "${APP_NAME_LC}-${RELEASE_VERSION}-el8.x86_64.rpm" ) ]]; then
             echo "Building on Linux x64 because we have no RPM"
             export SHOULD_BUILD="yes"
           else
@@ -530,7 +530,7 @@ elif [[ "${ASSETS}" != "null" ]]; then
             export SHOULD_BUILD_APPIMAGE="no"
           fi
 
-          if [[ -z $( contains "amd64.snap" ) ]]; then
+          if [[ -z $( contains "${RELEASE_VERSION}_amd64.snap" ) ]]; then
             echo "Building on Linux x64 because we have no SNAP"
             export SHOULD_BUILD="yes"
           else

--- a/check_tags.sh
+++ b/check_tags.sh
@@ -265,7 +265,7 @@ elif [[ "${ASSETS}" != "null" ]]; then
             export SHOULD_BUILD_DEB="no"
           fi
 
-          if [[ -z $( contains "${APP_NAME_LC}-${RELEASE_VERSION}-el8.aarch64.rpm" ) ]]; then
+          if [[ -z $( contains "${APP_NAME_LC}-${RELEASE_VERSION}.*aarch64.rpm" ) ]]; then
             echo "Building on Linux arm64 because we have no RPM"
             export SHOULD_BUILD="yes"
           else
@@ -324,7 +324,7 @@ elif [[ "${ASSETS}" != "null" ]]; then
             export SHOULD_BUILD_DEB="no"
           fi
 
-          if [[ -z $( contains "${APP_NAME_LC}-${RELEASE_VERSION}-el8.armv7hl.rpm" ) ]]; then
+          if [[ -z $( contains "${APP_NAME_LC}-${RELEASE_VERSION}.*armv7hl.rpm" ) ]]; then
             echo "Building on Linux arm because we have no RPM"
             export SHOULD_BUILD="yes"
           else
@@ -507,7 +507,7 @@ elif [[ "${ASSETS}" != "null" ]]; then
             export SHOULD_BUILD_DEB="no"
           fi
 
-          if [[ -z $( contains "${APP_NAME_LC}-${RELEASE_VERSION}-el8.x86_64.rpm" ) ]]; then
+          if [[ -z $( contains "${APP_NAME_LC}-${RELEASE_VERSION}.*x86_64.rpm" ) ]]; then
             echo "Building on Linux x64 because we have no RPM"
             export SHOULD_BUILD="yes"
           else


### PR DESCRIPTION
## Problem

Every patch rebuild release is missing `.deb`, `.rpm`, and `.AppImage` packages. The downloads page on codexeditor.app shows broken `#` links for Linux Debian packages as a result.

**Root cause:** The `check` job in `stable-linux.yml` correctly sets `PATCH_REBUILD=true` (which makes `check_tags.sh` skip asset re-checking via `ASSETS="null"`), but this variable is never forwarded to the downstream `build` job. Without it, the `build` job's `check_tags.sh` falls into the `RECHECK_ASSETS` path, loads assets from the *previous* release, and matches old `.deb`/`.rpm`/`.AppImage` files through version-agnostic patterns like `contains "amd64.deb"` — incorrectly setting `SHOULD_BUILD_DEB="no"`.

Tarballs were unaffected because their checks already included the version number (e.g. `contains "${APP_NAME}-linux-x64-${RELEASE_VERSION}.tar.gz"`).

## Fix

### 1. Forward `PATCH_REBUILD` across job boundaries (`stable-linux.yml`, `stable-windows.yml`)

Added `PATCH_REBUILD` and `CUSTOM_RELEASE_VERSION` as outputs of the `check` job and passed them into the `build`, `reh_linux`, and `reh_alpine` job environments. This ensures the patch rebuild fast path (`ASSETS="null"`) is reached in all downstream jobs.

### 2. Make asset checks version-specific (`check_tags.sh`)

Changed 8 version-agnostic `contains` patterns to include `${RELEASE_VERSION}`, consistent with how tar/zip/exe/dmg checks already work:

- **DEBs:** `"arm64.deb"` → `"${APP_NAME_LC}_${RELEASE_VERSION}_arm64.deb"`
- **RPMs:** `"aarch64.rpm"` → `"${APP_NAME_LC}-${RELEASE_VERSION}.*aarch64.rpm"` (regex `.*` keeps it EL-version-agnostic)
- **Snaps:** `"amd64.snap"` → `"${RELEASE_VERSION}_amd64.snap"`
- **AppImage** left as-is (glibc version in filename prevents a clean pattern with `contains`)

Normal (non-patch-rebuild) builds are unaffected — empty `PATCH_REBUILD` fails the `== "true"` check, and the version-specific patterns match correctly when the release version hasn't changed.