### PR TITLE
Restore patch-rebuild.yml workflow gutted during PR-build development

### DIFF
--- a/.github/workflows/patch-rebuild.yml
+++ b/.github/workflows/patch-rebuild.yml
@@ -2,10 +2,125 @@ name: Patch Rebuild (Force Build)
 
 on:
   workflow_dispatch:
+    inputs:
+      quality:
+        description: "Build quality"
+        required: true
+        default: "stable"
+        type: choice
+        options:
+          - stable
+          - insider
+      reason:
+        description: 'Reason for rebuild (e.g., "Fix microphone patch", "Add new feature")'
+        required: true
+        type: string
+
+env:
+  APP_NAME: Codex
+  GH_REPO_PATH: ${{ github.repository }}
+  ORG_NAME: ${{ github.repository_owner }}
 
 jobs:
-  pr-build:
-    uses: genesis-ai-dev/codex/.github/workflows/pr-build.yml@feat/sideloader
-    with:
-      pr_number: '31'
-    secrets: inherit
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      ms_commit: ${{ steps.prepare.outputs.ms_commit }}
+      ms_tag: ${{ steps.prepare.outputs.ms_tag }}
+      release_version: ${{ steps.prepare.outputs.release_version }}
+      build_reason: ${{ steps.prepare.outputs.build_reason }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.STRONGER_GITHUB_TOKEN }}
+
+      - name: Prepare patch rebuild
+        id: prepare
+        env:
+          VSCODE_QUALITY: ${{ github.event.inputs.quality }}
+          BUILD_REASON: ${{ github.event.inputs.reason }}
+        run: |
+          echo "=== Patch Rebuild for ${VSCODE_QUALITY} ==="
+          echo "Reason: ${BUILD_REASON}"
+
+          # Get current version from upstream file
+          if [[ ! -f "./upstream/${VSCODE_QUALITY}.json" ]]; then
+            echo "Error: No upstream/${VSCODE_QUALITY}.json found"
+            exit 1
+          fi
+
+          MS_COMMIT=$( jq -r '.commit' "./upstream/${VSCODE_QUALITY}.json" )
+          MS_TAG=$( jq -r '.tag' "./upstream/${VSCODE_QUALITY}.json" )
+
+          echo "Current VS Code base: ${MS_TAG} (${MS_COMMIT})"
+          echo "ms_tag=${MS_TAG}" >> $GITHUB_OUTPUT
+          echo "ms_commit=${MS_COMMIT}" >> $GITHUB_OUTPUT
+
+          # Generate unique build version with timestamp
+          # Use same format as normal builds - Julian day calculation ensures later builds have higher versions
+          # Format: MS_TAG + (Julian day * 24 + hour) = 1.99.24260
+          # Since patch rebuilds happen AFTER original builds, they naturally get higher version numbers
+          # Note that a patch rebuild *could* be higher than an upstream vscodium build version, so it may not trigger an update notice if we have already patched more recently
+          TIME_PATCH=$(printf "%04d" $(($(date +%-j) * 24 + $(date +%-H))))
+
+          if [[ "${VSCODE_QUALITY}" == "insider" ]]; then
+            RELEASE_VERSION="${MS_TAG}${TIME_PATCH}-insider"
+          else
+            RELEASE_VERSION="${MS_TAG}${TIME_PATCH}"
+          fi
+
+          echo "Generated rebuild version: ${RELEASE_VERSION}"
+          echo "release_version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+          echo "build_reason=${BUILD_REASON}" >> $GITHUB_OUTPUT
+
+          # Create a patch rebuild marker
+          echo "=== PATCH REBUILD ===" > PATCH_REBUILD_INFO.md
+          echo "**Build Version:** ${RELEASE_VERSION}" >> PATCH_REBUILD_INFO.md
+          echo "**Base VS Code:** ${MS_TAG}" >> PATCH_REBUILD_INFO.md
+          echo "**Rebuild Reason:** ${BUILD_REASON}" >> PATCH_REBUILD_INFO.md
+          echo "**Build Date:** $(date)" >> PATCH_REBUILD_INFO.md
+          echo "**Commit:** ${{ github.sha }}" >> PATCH_REBUILD_INFO.md
+
+          # Commit build info for tracking
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git add PATCH_REBUILD_INFO.md
+          git commit -m "Patch rebuild: ${BUILD_REASON} (${RELEASE_VERSION})" || echo "No changes to commit"
+          git push || echo "No changes to push"
+
+  trigger-all-builds:
+    needs: prepare
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger all platform builds
+        env:
+          GITHUB_TOKEN: ${{ secrets.STRONGER_GITHUB_TOKEN }}
+          QUALITY: ${{ github.event.inputs.quality }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.release_version }}
+          BUILD_REASON: ${{ needs.prepare.outputs.build_reason }}
+        run: |
+          echo "🚀 Triggering PATCH REBUILD for all platforms"
+          echo "Version: ${RELEASE_VERSION}"
+          echo "Reason: ${BUILD_REASON}"
+
+          # Force build by using repository dispatch with special payload
+          # This single dispatch will trigger all OS workflows that listen for this quality
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/dispatches \
+            -d "{
+              \"event_type\": \"${QUALITY}\",
+              \"client_payload\": {
+                \"quality\": \"${QUALITY}\",
+                \"patch_rebuild\": true,
+                \"force_build\": true,
+                \"build_reason\": \"${BUILD_REASON}\",
+                \"release_version\": \"${RELEASE_VERSION}\"
+              }
+            }"
+
+          echo "✅ Triggered all ${QUALITY} platform builds"


### PR DESCRIPTION
Restores `.github/workflows/patch-rebuild.yml` to its pre-1cf855f form. The workflow was replaced with a dev-time stub targeting `pr-build.yml@feat/sideloader` with a hardcoded PR number — it can't produce a stable release in that state.

## Changes

- `.github/workflows/patch-rebuild.yml` — restored byte-identically from `1cf855f~1`. Two jobs: `prepare` (compute time-based RELEASE_VERSION, commit `PATCH_REBUILD_INFO.md`) and `trigger-all-builds` (`repository_dispatch: [${quality}]` with `patch_rebuild: true` and `custom_release_version`).

No other files touched — the downstream `PATCH_REBUILD` / `CUSTOM_RELEASE_VERSION` plumbing in `stable-{linux,macos,windows}.yml` is still in place and was not affected by the 48h of CI changes.

## Test plan

- [ ] `git diff 1cf855f~1 -- .github/workflows/patch-rebuild.yml` is empty (confirmed locally).
- [ ] After merge, the Actions tab shows "Patch Rebuild (Force Build)" with the `quality` (stable/insider) + `reason` inputs restored.
- [ ] Optional: dispatch once with `quality=stable`, `reason="verify restore"` to confirm the marker commit lands on master and the three `stable-*` workflows are triggered via repository_dispatch. Only do this if a real forced rebuild is desired; it will produce a live release.